### PR TITLE
Allow any ssh-user while cloning from git

### DIFF
--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -5,7 +5,6 @@ import (
 	_ "crypto/sha256" // for opencontainers/go-digest
 	"encoding/json"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -207,8 +206,6 @@ const (
 	gitProtocolUnknown
 )
 
-var gitSSHRegex = regexp.MustCompile("^[a-z0-9]+@[^:]+:.*$")
-
 func getGitProtocol(remote string) (string, int) {
 	prefixes := map[string]int{
 		"http://":  gitProtocolHTTP,
@@ -224,7 +221,7 @@ func getGitProtocol(remote string) (string, int) {
 		}
 	}
 
-	if protocolType == gitProtocolUnknown && gitSSHRegex.MatchString(remote) {
+	if protocolType == gitProtocolUnknown && sshutil.IsSSHTransport(remote) {
 		protocolType = gitProtocolSSH
 	}
 

--- a/client/llb/source.go
+++ b/client/llb/source.go
@@ -207,7 +207,7 @@ const (
 	gitProtocolUnknown
 )
 
-var gitSSHRegex = regexp.MustCompile("^([a-z0-9]+@)?[^:]+:.*$")
+var gitSSHRegex = regexp.MustCompile("^[a-z0-9]+@[^:]+:.*$")
 
 func getGitProtocol(remote string) (string, int) {
 	prefixes := map[string]int{

--- a/source/gitidentifier.go
+++ b/source/gitidentifier.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -17,6 +18,8 @@ type GitIdentifier struct {
 	MountSSHSock     string
 	KnownSSHHosts    string
 }
+
+var gitSSHRegex = regexp.MustCompile("^([a-z0-9]+@)?[^:]+:.*$")
 
 func NewGitIdentifier(remoteURL string) (*GitIdentifier, error) {
 	repo := GitIdentifier{}
@@ -58,7 +61,7 @@ func (i *GitIdentifier) ID() string {
 // isGitTransport returns true if the provided str is a git transport by inspecting
 // the prefix of the string for known protocols used in git.
 func isGitTransport(str string) bool {
-	return strings.HasPrefix(str, "http://") || strings.HasPrefix(str, "https://") || strings.HasPrefix(str, "git://") || strings.HasPrefix(str, "git@")
+	return strings.HasPrefix(str, "http://") || strings.HasPrefix(str, "https://") || strings.HasPrefix(str, "git://") || gitSSHRegex.MatchString(str)
 }
 
 func getRefAndSubdir(fragment string) (ref string, subdir string) {

--- a/source/gitidentifier.go
+++ b/source/gitidentifier.go
@@ -19,7 +19,7 @@ type GitIdentifier struct {
 	KnownSSHHosts    string
 }
 
-var gitSSHRegex = regexp.MustCompile("^([a-z0-9]+@)?[^:]+:.*$")
+var gitSSHRegex = regexp.MustCompile("^[a-z0-9]+@[^:]+:.*$")
 
 func NewGitIdentifier(remoteURL string) (*GitIdentifier, error) {
 	repo := GitIdentifier{}

--- a/source/gitidentifier.go
+++ b/source/gitidentifier.go
@@ -2,9 +2,9 @@ package source
 
 import (
 	"net/url"
-	"regexp"
 	"strings"
 
+	"github.com/moby/buildkit/util/sshutil"
 	"github.com/pkg/errors"
 )
 
@@ -18,8 +18,6 @@ type GitIdentifier struct {
 	MountSSHSock     string
 	KnownSSHHosts    string
 }
-
-var gitSSHRegex = regexp.MustCompile("^[a-z0-9]+@[^:]+:.*$")
 
 func NewGitIdentifier(remoteURL string) (*GitIdentifier, error) {
 	repo := GitIdentifier{}
@@ -61,7 +59,7 @@ func (i *GitIdentifier) ID() string {
 // isGitTransport returns true if the provided str is a git transport by inspecting
 // the prefix of the string for known protocols used in git.
 func isGitTransport(str string) bool {
-	return strings.HasPrefix(str, "http://") || strings.HasPrefix(str, "https://") || strings.HasPrefix(str, "git://") || gitSSHRegex.MatchString(str)
+	return strings.HasPrefix(str, "http://") || strings.HasPrefix(str, "https://") || strings.HasPrefix(str, "git://") || sshutil.IsSSHTransport(str)
 }
 
 func getRefAndSubdir(fragment string) (ref string, subdir string) {

--- a/util/sshutil/transport_validation.go
+++ b/util/sshutil/transport_validation.go
@@ -1,0 +1,11 @@
+package sshutil
+
+import (
+	"regexp"
+)
+
+var gitSSHRegex = regexp.MustCompile("^[a-z0-9]+@[a-zA-Z0-9-.]+:.*$")
+
+func IsSSHTransport(s string) bool {
+	return gitSSHRegex.MatchString(s)
+}

--- a/util/sshutil/transport_validation.go
+++ b/util/sshutil/transport_validation.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 )
 
-var gitSSHRegex = regexp.MustCompile("^[a-z0-9]+@[a-zA-Z0-9-.]+:.*$")
+var gitSSHRegex = regexp.MustCompile("^[a-z0-9-_]+@[a-zA-Z0-9-.]+:.*$")
 
 func IsSSHTransport(s string) bool {
 	return gitSSHRegex.MatchString(s)

--- a/util/sshutil/transport_validation_test.go
+++ b/util/sshutil/transport_validation_test.go
@@ -1,0 +1,14 @@
+package sshutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSSHTransport(t *testing.T) {
+	require.False(t, IsSSHTransport("http://github.com/moby/buildkit"))
+	require.False(t, IsSSHTransport("github.com/moby/buildkit"))
+	require.True(t, IsSSHTransport("git@github.com:moby/buildkit.git"))
+	require.True(t, IsSSHTransport("nonstandarduser@example.com:/srv/repos/weird/project.git"))
+}

--- a/util/sshutil/transport_validation_test.go
+++ b/util/sshutil/transport_validation_test.go
@@ -9,6 +9,15 @@ import (
 func TestIsSSHTransport(t *testing.T) {
 	require.False(t, IsSSHTransport("http://github.com/moby/buildkit"))
 	require.False(t, IsSSHTransport("github.com/moby/buildkit"))
+	require.False(t, IsSSHTransport("github.com:moby/buildkit.git"))
+	require.False(t, IsSSHTransport("helloworld.net"))
+	require.False(t, IsSSHTransport("git@helloworld.net"))
+	require.False(t, IsSSHTransport("git@helloworld.net/foo/bar.git"))
+	require.False(t, IsSSHTransport("bad:user@helloworld.net:foo/bar.git"))
+	require.False(t, IsSSHTransport(""))
 	require.True(t, IsSSHTransport("git@github.com:moby/buildkit.git"))
 	require.True(t, IsSSHTransport("nonstandarduser@example.com:/srv/repos/weird/project.git"))
+	require.True(t, IsSSHTransport("other_funky-username52@example.com:path/to/repo.git/"))
+	require.True(t, IsSSHTransport("other_funky-username52@example.com:/to/really:odd:repo.git/"))
+	require.True(t, IsSSHTransport("teddy@4houses-down.com:/~/catnip.git/"))
 }


### PR DESCRIPTION
- this allows one to use a non-standard ssh username like repo@host
rather than assuming it must be git@host

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>